### PR TITLE
Fix `astery` typo.

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,12 +1,6 @@
 Repo for developing organizational documents using the collaboration tools 
-and processes associated with software development.  
+and processes associated with software development.
 
 Specifically "competencies" 
 are a tool to discuss the skills and capabilities needed in various roles and 
-what those skills look like when demonstrated at progressive levels of mastery. 
-
-
-
-
-
-
+what those skills look like when demonstrated at progressive levels of mastery.

--- a/competencies/roles/_TechWideGeneral.md
+++ b/competencies/roles/_TechWideGeneral.md
@@ -37,7 +37,7 @@
         <td><ul>
             <!--- Authority -->
             <li>Connected within the industry; leverages network actively</li>
-            <li>astery of business drivers and unit economics</li>
+            <li>Mastery of business drivers and unit economics</li>
             <li>Nuanced understanding of cross-functional dependencies</li>
             <li>Sees and unlocks opportunities that create value for the business</li>
         </ul></td>


### PR DESCRIPTION
While we were going through this during today's eng team update I
noticed this typo.

This commit also removes some extra whitespace from the README.