### PR TITLE
Fix typo in `Proficent` comment.

### DIFF
--- a/competencies/roles/DataScience.md
+++ b/competencies/roles/DataScience.md
@@ -32,7 +32,7 @@ with [Developers](./Developer.md)/[DataEngineers](./DataEngineer.md) but also wi
             <li>Effective at soliciting feedback on the effectiveness of analysis in solving problems.</li>
         </ul></td>
         <td><ul>
-            <!--- Proficent  -->
+            <!--- Proficient  -->
             <li>Active participation and outreach in explorating an ambiguous space, mapping to technical space, and communicating implications effectively.</li>
             <li>Can participate in a business level objectives discussion and develop testable data hypotheses.</li>
             <li>Systematically approach questions of effectiveness and identify adjacent opportunities or questions;
@@ -59,7 +59,7 @@ with [Developers](./Developer.md)/[DataEngineers](./DataEngineer.md) but also wi
             <li>Avoids inference and sticks to observation of relationship</li>
         </ul></td>
         <td><ul>
-            <!--- Proficent  -->
+            <!--- Proficient  -->
             <li>Able to apply a variety of techniques and assess their relevance to the problem space</li>
             <li>Broad set of techniques practiced, able to understand the applicability of advanced techniques and implement or integrate</li>
             <li>Proficient with tooling for advance processing (R, Python, sql windowing functions, etc.)</li>
@@ -87,7 +87,7 @@ with [Developers](./Developer.md)/[DataEngineers](./DataEngineer.md) but also wi
             <li>Knows how to use the ml libraries in at least one environment (e.g. python sklearn…)</li>
         </ul></td>
         <td><ul>
-            <!--- Proficent  -->
+            <!--- Proficient  -->
             <li>Connect research on the problem structure we want to solve to identify likely effective algorithms</li>
             <li>Iterate on model alternatives and constructions</li>
             <li>Proficient at tuning, troubleshooting and assessing subtle model issues.</li>
@@ -115,7 +115,7 @@ with [Developers](./Developer.md)/[DataEngineers](./DataEngineer.md) but also wi
             <li>Understands different audiences and can respond to requests for changes in complexity and narrative</li>
         </ul></td>
         <td><ul>
-            <!--- Proficent  -->
+            <!--- Proficient  -->
             <li>Actively designs for audience and purpose of report
             <li>Can develop Reports and visualizations that can simplify complex information substantially or can identify important nuance</li>
             <li>Can produce reports and visualizations to explore and find insights in a general domain</li>

--- a/competencies/roles/Developer.md
+++ b/competencies/roles/Developer.md
@@ -36,7 +36,7 @@ As well as the role specific competencies below, all tech roles in properly invo
             <li>Values and adopts team norms related to the development process (testing, release, code review, tech decisions)</li>
         </ul></td>
         <td><ul>
-            <!--- Proficent  -->
+            <!--- Proficient  -->
             <li>Advocates and incorporates processes that have been successful for them in the past (testing, release, code review, tech decisions)</li>
             <li>Has a "reason for practice/process change" framework and seeks out ways of improving their craft</li>
             <li>Mental model of the impact of particular processes, actively identifies processes that don't seem to be effective</li>
@@ -59,7 +59,7 @@ As well as the role specific competencies below, all tech roles in properly invo
             <li>Understands and accepts importance of system design, and understands that relative importance is situational and has a cost</li>
         </ul></td>
         <td><ul>
-            <!--- Proficent  -->
+            <!--- Proficient  -->
             <li>Actively develops and tests for relevant system issues (what happens in failure, how is the latency)</li>
             <li>Routinely considers most important system characteristics in designs (e.g. latency vs throughput vs resilience)</li>
             <li>Routinely raises system relevant system design factors, and helps team disregard irrelevant (latency on background process, testability of one time script)</li>
@@ -84,7 +84,7 @@ As well as the role specific competencies below, all tech roles in properly invo
             <li>Given tech design goals can identify a development approach to breaking down a problem</li>
         </ul></td>
         <td><ul>
-            <!--- Proficent  -->
+            <!--- Proficient  -->
             <li>A trusted member of the team taking ownership of important system components</li>
             <li>Collaborates on tech approaches, routinely provides valuable ideas in design and code review</li>
             <li>Influences immediate team on tech design and design criteria</li>
@@ -110,7 +110,7 @@ As well as the role specific competencies below, all tech roles in properly invo
             Not Applicable.
         </ul></td>
         <td><ul>
-            <!--- Proficent  -->
+            <!--- Proficient  -->
             <li>Demonstrated ability to support and contribute to long term or high impact changes</li>
             <li>Recognizes the human and team connection to big changes</li>
             <li>Understands tradeoffs between major technical systems and approaches</li>

--- a/competencies/roles/TechLeader.md
+++ b/competencies/roles/TechLeader.md
@@ -44,7 +44,7 @@ As well as the role specific competencies below, all tech roles in properly invo
             <li>Codevelops a reasonable learning and development plan for team with support from other leaders.</li>
         </ul></td>
         <td><ul>
-            <!--- Proficent  -->
+            <!--- Proficient  -->
             <li>Actively assessing and focusing on team motivation.</li>
             <li>Actively provides frequent feedback that provides reinforcement and career development and improves team member contributions</li>
             <li>Capable of self improvement of leadership by soliciting and responding to teams feedback and adapting approach</li>
@@ -70,7 +70,7 @@ As well as the role specific competencies below, all tech roles in properly invo
             <li>Situational awareness of meeting dynamics (stress, conflict, disengagment, confusion, etc.)</li>
         </ul></td>
         <td><ul>
-            <!--- Proficent  -->
+            <!--- Proficient  -->
             <li>Deploys varied tools to deliver varied outcomes (input vs decision making vs alignment). Team decision quality goes up in their presence</li>
             <li>Ensures relevant voices are present and heard especially based on different communication style or role</li>
             <li>Reflects on and solicits improvements to meetings and communication activities; each iteration tends to improve</li>
@@ -95,7 +95,7 @@ As well as the role specific competencies below, all tech roles in properly invo
             <li>Has a general sense of team progress and items that may have interrupted or slowed them down in the previous period</li>
         </ul></td>
         <td><ul>
-            <!--- Proficent  -->
+            <!--- Proficient  -->
             <li>Actively decomposing product goals into technical dependencies and risks along with technical leaders</li>
             <li>Continuously focusing the team on stories and approaches that achieve prioritization goals (impact, or learning or generating options)</li>
             <li>Make visible tradeoffs and choices within the team</li>
@@ -123,7 +123,7 @@ As well as the role specific competencies below, all tech roles in properly invo
             <li>Understands manager/leader importance in bidirectional alignment and capable of relaying plans and feedback between parts of the organization</li>
         </ul></td>
         <td><ul>
-            <!--- Proficent  -->
+            <!--- Proficient  -->
             <li>Creates opportunities to link activities to outcomes, can provide feedback and perspective in terms of direction</li>
             <li>Effective at generate outcomes for self and others that fit into a larger picture</li>
             <li>Effective at highlighting unnecessary goals or hidden implications</li>

--- a/competencies/roles/_TechWideGeneral.md
+++ b/competencies/roles/_TechWideGeneral.md
@@ -27,7 +27,7 @@
             <li>Understands most metrics and basic financial analysis</li>
         </ul></td>
         <td><ul>
-            <!--- Proficent  -->
+            <!--- Proficient  -->
             <li>Considers medium to long term implications of strategic decisions </li>
             <li>Demonstrates ability to direct energy toward areas of opportunity and risk </li>
             <li>Stays current on industry trends and proactively “imports” best practice </li>
@@ -54,7 +54,7 @@
             <li>Presents material in small group settings; occasionally large-group settings</li>
         </ul></td>
         <td><ul>
-            <!--- Proficent  -->
+            <!--- Proficient  -->
             <li>Adapts communication style to suit the audience</li>
             <li>Independently manages large group meetings</li>
             <li>Listens to differing opinions and shifts perspective dynamically</li>
@@ -84,7 +84,7 @@
             <li>Shows resourcefulness and willingness to get more done with less</li>
         </ul></td>
         <td><ul>
-            <!--- Proficent  -->
+            <!--- Proficient  -->
             <li>Anticipates need to shift resources based on new information</li>
             <li>Capable of juggling multiple workstreams</li>
             <li>Takes initiative to automate, innovate, and improve efficiency of operations</li>
@@ -108,7 +108,7 @@
             <li>Seeks opportunity to share knowledge, learning with others.</li>
         </ul></td>
         <td><ul>
-            <!--- Proficent  -->
+            <!--- Proficient  -->
             <li>Exercises assumption of good-intent within and across teams</li>
             <li>Takes regular opportunities to give and solicit feedback</li>
         </ul></td>

--- a/competencies/roles/_template.md
+++ b/competencies/roles/_template.md
@@ -33,7 +33,7 @@ As well as the role specific competencies below, all tech roles in properly invo
 		    Example of early demonstration
 		</ul></td>
 		<td><ul>
-		<!--- Proficent  -->
+		<!--- Proficient  -->
 		    Example of proficient demonstration
 		</ul></td>
 		<td><ul>


### PR DESCRIPTION
This commit fixes a typo in a comment of the roles files. I noticed this
while working on fixing this other typo:
https://github.com/GoProperly/organization/pull/7