### PR TITLE
Add role mapping for data science

### DIFF
--- a/competencies/roles/DataScience.md
+++ b/competencies/roles/DataScience.md
@@ -129,5 +129,21 @@ with [Developers](./Developer.md)/[DataEngineers](./DataEngineer.md) but also wi
             <li>Routinely identifies important areas to report and visualize</li>
         </ul></td>
     </tr>
+    <tr>
+        <td>
+            <strong> System Design from <a href="./Developer.md">Developer</a> </strong>
+        </td>
+        <td/>
+        <td/>
+        <td/>
+    </tr>
+    <tr>
+        <td>
+            <strong> Tech Design, Implementation and Code Ownership from <a href="./Developer.md">Developer</a> </strong>
+        </td>
+        <td/>
+        <td/>
+        <td/>
+    </tr>
 </table>
 

--- a/competencies/roles/DataScienceLevelMapping.md
+++ b/competencies/roles/DataScienceLevelMapping.md
@@ -9,7 +9,7 @@ a role family called Machine Learning Engineer
 | --------------------------- |:-------------------------:| ----------------------------:| ----------:|
 | Data Science I (junior)     |                           | 90% emerging; 10% proficient |  New Grad, or first one or two years |
 | Data Science II             | Proficient: "Machine Learning Analysis"      |  50% emerging, 50% proficient  |   |
-| Data Science III a (senior) | Proficient: "Error, Causality, Inference" | 60%% proficient; some authority  |  | 
+| Data Science III a (senior) | Proficient: "Error, Causality, Inference" | 75% proficient; some authority  |  | 
 | Data Science III b (senior) |                           | 90% proficient; some authority  | High end to end impact; Strength: "Business Alignment" and "Communication"  | 
 | Principle Data Scientist    | All DS specific | 50% Proficient; 50% Authority | Strong self awareness, Strong on general areas such as business acumen | 
 
@@ -17,7 +17,7 @@ a role family called Machine Learning Engineer
 
 | Title/Job                   | Key Competenies           | Other Competencies           |     Notes  |
 | --------------------------- |:-------------------------:| ----------------------------:| ----------:|
-| Machine Learning Engineer III  | Proficient: "Machine Learning Analysis"  and "Tech Design, Implementation and Code Ownership"   |  50% emerging, 50% proficient  |  Comparable to SWDev III |
-| Data Science III a (senior) | Proficient: "Error, Causality, Inference" and "System Design" | 50% proficient; some authority  |  | 
-| Data Science III b (senior) |                           | 90% proficient; some authority  | High end to end impact; Strength: "Business Alignment" and "Communication"  | 
-| Principle Data Scientist    | All DS specific | 50% Proficient; 50% Authority | Strong self awareness, Strong on general areas such as business acumen | 
+| Machine Learning Engineer II  | Proficient: "Machine Learning Analysis"  and "Tech Design, Implementation and Code Ownership"   |  50% emerging, 50% proficient  |  Comparable to SWDev III |
+| Machine Learning Engineer III a (senior) | Proficient: "Error, Causality, Inference" and "System Design" | 75% proficient; some authority  |  | 
+| Machine Learning Engineer III b (senior) |                           | 90% proficient; some authority  | High end to end impact; Strength: "Business Alignment" and "Communication"  | 
+| Principle Machine Learning Engineer   | All DS specific | 50% Proficient; 50% Authority | Strong self awareness, Strong on general areas such as business acumen | 

--- a/competencies/roles/DataScienceLevelMapping.md
+++ b/competencies/roles/DataScienceLevelMapping.md
@@ -1,5 +1,8 @@
 The three categories of competencies can be used to map to typical job titles specific roles. 
 
+This framework also uses the [Developer](./Developer.md)  competencies of 
+"Tech Design, Implementation and Code Ownership" and of "System Design" to create 
+a role family called Machine Learning Engineer
 
 
 | Title/Job                   | Key Competenies           | Other Competencies           |     Notes  |
@@ -7,5 +10,14 @@ The three categories of competencies can be used to map to typical job titles sp
 | Data Science I (junior)     |                           | 90% emerging; 10% proficient |  New Grad, or first one or two years |
 | Data Science II             | Proficient: "Machine Learning Analysis"      |  50% emerging, 50% proficient  |   |
 | Data Science III a (senior) | Proficient: "Error, Causality, Inference" | 60%% proficient; some authority  |  | 
+| Data Science III b (senior) |                           | 90% proficient; some authority  | High end to end impact; Strength: "Business Alignment" and "Communication"  | 
+| Principle Data Scientist    | All DS specific | 50% Proficient; 50% Authority | Strong self awareness, Strong on general areas such as business acumen | 
+
+
+
+| Title/Job                   | Key Competenies           | Other Competencies           |     Notes  |
+| --------------------------- |:-------------------------:| ----------------------------:| ----------:|
+| Machine Learning Engineer III  | Proficient: "Machine Learning Analysis"  and "Tech Design, Implementation and Code Ownership"   |  50% emerging, 50% proficient  |  Comparable to SWDev III |
+| Data Science III a (senior) | Proficient: "Error, Causality, Inference" and "System Design" | 50% proficient; some authority  |  | 
 | Data Science III b (senior) |                           | 90% proficient; some authority  | High end to end impact; Strength: "Business Alignment" and "Communication"  | 
 | Principle Data Scientist    | All DS specific | 50% Proficient; 50% Authority | Strong self awareness, Strong on general areas such as business acumen | 

--- a/competencies/roles/DataScienceLevelMapping.md
+++ b/competencies/roles/DataScienceLevelMapping.md
@@ -7,7 +7,7 @@ a role family called Machine Learning Engineer
 
 | Title/Job                   |  Industry Comparison       | Key Competenies                                                     | Other Competencies              |     Notes  |
 | --------------------------- |:-------------------------- |:-------------------------------------------------------------------:| -------------------------------:| ----------:|
-| Data Science II             |  L1 typically 1-2 years    |                                                                     |  75% emerging, 25% proficient   |  New Grad, or first one or two years |
+| Data Science II             |  L1 typically 1-2 years    |                                                                     |  75% emerging, 25% proficient   | typically first one or two years |
 | Data Science III            |  L2 typically 2-4 years    | Proficient: "Machine Learning Analysis"                             | 50% emerging, 50% proficient    |   |
 | Data Science IV             |  L3 typically 5+  years    | Proficient: "Error, Causality, Inference"                           | 50% proficient; some authority  |  | 
 | Data Science V              |  L3 typically < 8 years    |  Proficient or Authority  "Business Alignment" and "Communication"  | 75% proficient; some authority  | High end to end impact; | 

--- a/competencies/roles/DataScienceLevelMapping.md
+++ b/competencies/roles/DataScienceLevelMapping.md
@@ -5,19 +5,20 @@ This framework also uses the [Developer](./Developer.md)  competencies of
 a role family called Machine Learning Engineer
 
 
-| Title/Job                   | Key Competenies           | Other Competencies           |     Notes  |
-| --------------------------- |:-------------------------:| ----------------------------:| ----------:|
-| Data Science I (junior)     |                           | 90% emerging; 10% proficient |  New Grad, or first one or two years |
-| Data Science II             | Proficient: "Machine Learning Analysis"      |  50% emerging, 50% proficient  |   |
-| Data Science III a (senior) | Proficient: "Error, Causality, Inference" | 75% proficient; some authority  |  | 
-| Data Science III b (senior) |                           | 90% proficient; some authority  | High end to end impact; Strength: "Business Alignment" and "Communication"  | 
-| Principal Data Scientist    | All DS specific | 50% Proficient; 50% Authority | Strong self awareness, Strong on general areas such as business acumen | 
+| Title/Job                   |  Industry Comparison       | Key Competenies                                                     | Other Competencies              |     Notes  |
+| --------------------------- |:-------------------------- |:-------------------------------------------------------------------:| -------------------------------:| ----------:|
+| Data Science II             |  L1 typically 1-2 years    |                                                                     |  75% emerging, 25% proficient   |  New Grad, or first one or two years |
+| Data Science III            |  L2 typically 2-4 years    | Proficient: "Machine Learning Analysis"                             | 50% emerging, 50% proficient    |   |
+| Data Science IV             |  L3 typically 5+  years    | Proficient: "Error, Causality, Inference"                           | 50% proficient; some authority  |  | 
+| Data Science V              |  L3 typically < 8 years    |  Proficient or Authority  "Business Alignment" and "Communication"  | 75% proficient; some authority  | High end to end impact; | 
+| Principal Data Scientist    |  L4 not experience related | Proficient or Authority all DS specific                             | 50% Proficient; 50% Authority   | Strong self awareness, Strong on general areas such as business acumen | 
+          
 
-
-
-| Title/Job                   | Key Competenies           | Other Competencies           |     Notes  |
-| --------------------------- |:-------------------------:| ----------------------------:| ----------:|
-| Machine Learning Engineer II  | Proficient: "Machine Learning Analysis"  and "Tech Design, Implementation and Code Ownership"   |  50% emerging, 50% proficient  |  Comparable to SWDev III |
-| Machine Learning Engineer III a (senior) | Proficient: "Error, Causality, Inference" and "System Design" | 75% proficient; some authority  |  | 
-| Machine Learning Engineer III b (senior) |                           | 90% proficient; some authority  | High end to end impact; Strength: "Business Alignment" and "Communication"  | 
-| Principal Machine Learning Engineer   | All DS specific | 50% Proficient; 50% Authority | Strong self awareness, Strong on general areas such as business acumen | 
+                                                                                                                                                                                                     
+| Title/Job                             |  Industry Comparison       | Key Competencies                                                                                | Other Competencies              |     Notes  |
+| ------------------------------------- |:-------------------------- |:-----------------------------------------------------------------------------------------------:| -------------------------------:| ----------:|
+| Machine Learning Engineer III         |  L2 typically 2-4 years    | Proficient: "Machine Learning Analysis"  and "Tech Design, Implementation and Code Ownership"   |  50% emerging, 50% proficient   |  Comparable to SWDev III |
+| Machine Learning Engineer IV          |  L3 typically 5+  years    | Proficient: "Error, Causality, Inference" and "System Design"                                   | 75% proficient; some authority  |  | 
+| Machine Learning Engineer V           |  L3 typically < 8 years    |  Proficient or Authority "Communication" and "Technical Change"                                 | 90% proficient; some authority  | High end to end impact software and data systems;   | 
+| Principal Machine Learning Engineer   |  L4 not experience related | All DS specific                                                                                 | 50% Proficient; 50% Authority   | Strong self awareness, Strong on general areas such as business acumen | 
+                                       

--- a/competencies/roles/DataScienceLevelMapping.md
+++ b/competencies/roles/DataScienceLevelMapping.md
@@ -1,0 +1,11 @@
+The three categories of competencies can be used to map to typical job titles specific roles. 
+
+
+
+| Title/Job                   | Key Competenies           | Other Competencies           |     Notes  |
+| --------------------------- |:-------------------------:| ----------------------------:| ----------:|
+| Data Science I (junior)     |                           | 90% emerging; 10% proficient |  New Grad, or first one or two years |
+| Data Science II             | Proficient: "Machine Learning Analysis"      |  50% emerging, 50% proficient  |   |
+| Data Science III a (senior) | Proficient: "Error, Causality, Inference" | 60%% proficient; some authority  |  | 
+| Data Science III b (senior) |                           | 90% proficient; some authority  | High end to end impact; Strength: "Business Alignment" and "Communication"  | 
+| Principle Data Scientist    | All DS specific | 50% Proficient; 50% Authority | Strong self awareness, Strong on general areas such as business acumen | 

--- a/competencies/roles/DataScienceLevelMapping.md
+++ b/competencies/roles/DataScienceLevelMapping.md
@@ -11,7 +11,7 @@ a role family called Machine Learning Engineer
 | Data Science II             | Proficient: "Machine Learning Analysis"      |  50% emerging, 50% proficient  |   |
 | Data Science III a (senior) | Proficient: "Error, Causality, Inference" | 75% proficient; some authority  |  | 
 | Data Science III b (senior) |                           | 90% proficient; some authority  | High end to end impact; Strength: "Business Alignment" and "Communication"  | 
-| Principle Data Scientist    | All DS specific | 50% Proficient; 50% Authority | Strong self awareness, Strong on general areas such as business acumen | 
+| Principal Data Scientist    | All DS specific | 50% Proficient; 50% Authority | Strong self awareness, Strong on general areas such as business acumen | 
 
 
 
@@ -20,4 +20,4 @@ a role family called Machine Learning Engineer
 | Machine Learning Engineer II  | Proficient: "Machine Learning Analysis"  and "Tech Design, Implementation and Code Ownership"   |  50% emerging, 50% proficient  |  Comparable to SWDev III |
 | Machine Learning Engineer III a (senior) | Proficient: "Error, Causality, Inference" and "System Design" | 75% proficient; some authority  |  | 
 | Machine Learning Engineer III b (senior) |                           | 90% proficient; some authority  | High end to end impact; Strength: "Business Alignment" and "Communication"  | 
-| Principle Machine Learning Engineer   | All DS specific | 50% Proficient; 50% Authority | Strong self awareness, Strong on general areas such as business acumen | 
+| Principal Machine Learning Engineer   | All DS specific | 50% Proficient; 50% Authority | Strong self awareness, Strong on general areas such as business acumen | 

--- a/competencies/roles/DeveloperLevelMapping.md
+++ b/competencies/roles/DeveloperLevelMapping.md
@@ -9,5 +9,5 @@ The three categories of competencies can be used to map to typical job titles sp
 | SW Dev III (intermediate) | Proficient: "Tech Design, Implementation and Code Ownership" | 50% emerging, 50% proficient   | Strong in knowledge and execution |
 | SW Dev IV (senior I)      | Proficient: "System Design"                                  | 50% proficient; some authority | May be expert or generalist  |
 | SW Dev V (senior II)      | Proficient: "Communication"                                  | 75% proficient; some authority | Expanded impact across teams / org |
-| Principle SW Dev          | Proficient: "Technical Change"                               | 50% Proficient; 50% Authority  | Strong self awareness, Strong on general areas such as business acumen |
+| Principal SW Dev          | Proficient: "Technical Change"                               | 50% Proficient; 50% Authority  | Strong self awareness, Strong on general areas such as business acumen |
 | Distinguished             | Authority: "Technical Change"                                |                                | Broad authority or extreme depth in a technical branch |

--- a/competencies/roles/DeveloperLevelMapping.md
+++ b/competencies/roles/DeveloperLevelMapping.md
@@ -2,12 +2,12 @@ The three categories of competencies can be used to map to typical job titles sp
 
 
 
-| Title/Job           | Key Competencies           | Other Competencies           |     Notes  |
-| ------------------- |:-------------------------:| ----------------------------:| ----------:|
-| SW Dev I (junior)   |   |   |  New Grad, or first one or two years |
-| SW Dev II           |   |  75% emerging, 25% proficient  | Integrated into the software practice at Properly |
-| SW Dev III (intermediate) | Proficient: "Tech Design, Implementation and Code Ownership" | 50% emerging, 50% proficient | Strong in knowledge and execution |
-| SW Dev IV (senior I) | Proficient: "System Design" | 50% proficient; some authority  | May be expert or generalist  |
-| SW Dev V (senior II) | Proficient: "Communication" | 75% proficient; some authority  | Expanded impact across teams / org |
-| Principle SW Dev    | Proficient: "Technical Change" | 50% Proficient; 50% Authority | Strong self awareness, Strong on general areas such as business acumen |
-| Distinguished       | Authority: "Technical Change" | | Broad authority or extreme depth in a technical branch |
+| Title/Job                 | Key Competencies                                             | Other Competencies             |     Notes  |
+| ------------------------- |:------------------------------------------------------------:| ------------------------------:| ----------:|
+| SW Dev I (junior)         |                                                              |                                |  New Grad, or first one or two years |
+| SW Dev II                 |                                                              |  75% emerging, 25% proficient  | Integrated into the software practice at Properly |
+| SW Dev III (intermediate) | Proficient: "Tech Design, Implementation and Code Ownership" | 50% emerging, 50% proficient   | Strong in knowledge and execution |
+| SW Dev IV (senior I)      | Proficient: "System Design"                                  | 50% proficient; some authority | May be expert or generalist  |
+| SW Dev V (senior II)      | Proficient: "Communication"                                  | 75% proficient; some authority | Expanded impact across teams / org |
+| Principle SW Dev          | Proficient: "Technical Change"                               | 50% Proficient; 50% Authority  | Strong self awareness, Strong on general areas such as business acumen |
+| Distinguished             | Authority: "Technical Change"                                |                                | Broad authority or extreme depth in a technical branch |


### PR DESCRIPTION
Add role mapping for data science, added with two senior levels 

![image](https://user-images.githubusercontent.com/36340630/94069582-d6591f80-fdbe-11ea-9eef-4ebf9cc30b50.png)


Update: 

Added a machine learning engineer specialization and included two of the competencies from the developer role.  This enables data scientists to have a path to emphasize software development skills, and gives a path for senior software develoeprs to pick up core items like machine learning modelling and not have to "span roles" 
