### PR TITLE
Technical Change Competency

### DIFF
--- a/competencies/roles/Developer.md
+++ b/competencies/roles/Developer.md
@@ -108,7 +108,9 @@ As well as the role specific competencies below, all tech roles in properly invo
         </td>
         <td><ul>
             <!--- Emerging  -->
-            Not Applicable.
+            <li> Curious about the interactions of approaches and decisions on wider outcome </li>
+            <li> Questions and discusses organizational, business, customer, and technology interactions </li>
+            <li> "What if ... ?" </li> 
         </ul></td>
         <td><ul>
             <!--- Proficient  -->


### PR DESCRIPTION
Address issue that _something_ has to be "emerging"  before a proficiency.  

Added curiosity and questioning as the emerging activity leading to that technical change proficiency. 

Technical change remains an unlikely competency (not the focus) for early and intermediate developers. 