### PR TITLE
Level 4 and 5 roles more distinct

### DIFF
--- a/competencies/roles/DataScienceLevelMapping.md
+++ b/competencies/roles/DataScienceLevelMapping.md
@@ -9,7 +9,7 @@ a role family called Machine Learning Engineer
 | --------------------------- |:-------------------------- |:-------------------------------------------------------------------:| -------------------------------:| ----------:|
 | Data Science II             |  L1 typically 1-2 years    |                                                                     | 75% emerging, 25% proficient    | typically first one or two years |
 | Data Science III            |  L2 typically 2-4 years    | Proficient: "Machine Learning Analysis"                             | 50% emerging, 50% proficient    |   |
-| Data Science IV             |  L3 typically 5+  years    | Proficient: "Error, Causality, Inference"                           | 75% proficient                  |  | 
+| Data Science IV             |  L3 typically 5+  years    | Proficient: "Error, Causality, Inference"                           | 75% proficient or greater       |  | 
 | Data Science V              |  L3 typically < 8 years    |  Proficient or Authority  "Business Alignment" and "Communication"  | 25% authority                   | High end to end impact; | 
 | Principal Data Scientist    |  L4 not experience related | Proficient or Authority all DS specific                             | 50% Authority                   | Strong self awareness, Strong on general areas such as business acumen | 
           
@@ -18,7 +18,7 @@ a role family called Machine Learning Engineer
 | Title/Job                             |  Industry Comparison       | Key Competencies                                                                                | Other Competencies              |     Notes  |
 | ------------------------------------- |:-------------------------- |:-----------------------------------------------------------------------------------------------:| -------------------------------:| ----------:|
 | Machine Learning Engineer III         |  L2 typically 2-4 years    | Proficient: "Machine Learning Analysis"  and "Tech Design, Implementation and Code Ownership"   | 50% emerging, 50% proficient    |  Comparable to SWDev III |
-| Machine Learning Engineer IV          |  L3 typically 5+  years    | Proficient: "Error, Causality, Inference" and "System Design"                                   | 75% proficient                  |  | 
+| Machine Learning Engineer IV          |  L3 typically 5+  years    | Proficient: "Error, Causality, Inference" and "System Design"                                   | 75% proficient or greater       |  | 
 | Machine Learning Engineer V           |  L3 typically < 8 years    |  Proficient or Authority "Communication" and "Technical Change"                                 | 25% authority                   | High end to end impact software and data systems;   | 
 | Principal Machine Learning Engineer   |  L4 not experience related | All DS specific                                                                                 | 50% Authority                   | Strong self awareness, Strong on general areas such as business acumen | 
                                        

--- a/competencies/roles/DataScienceLevelMapping.md
+++ b/competencies/roles/DataScienceLevelMapping.md
@@ -7,18 +7,18 @@ a role family called Machine Learning Engineer
 
 | Title/Job                   |  Industry Comparison       | Key Competenies                                                     | Other Competencies              |     Notes  |
 | --------------------------- |:-------------------------- |:-------------------------------------------------------------------:| -------------------------------:| ----------:|
-| Data Science II             |  L1 typically 1-2 years    |                                                                     |  75% emerging, 25% proficient   | typically first one or two years |
+| Data Science II             |  L1 typically 1-2 years    |                                                                     | 75% emerging, 25% proficient    | typically first one or two years |
 | Data Science III            |  L2 typically 2-4 years    | Proficient: "Machine Learning Analysis"                             | 50% emerging, 50% proficient    |   |
-| Data Science IV             |  L3 typically 5+  years    | Proficient: "Error, Causality, Inference"                           | 50% proficient; some authority  |  | 
-| Data Science V              |  L3 typically < 8 years    |  Proficient or Authority  "Business Alignment" and "Communication"  | 75% proficient; some authority  | High end to end impact; | 
-| Principal Data Scientist    |  L4 not experience related | Proficient or Authority all DS specific                             | 50% Proficient; 50% Authority   | Strong self awareness, Strong on general areas such as business acumen | 
+| Data Science IV             |  L3 typically 5+  years    | Proficient: "Error, Causality, Inference"                           | 75% proficient                  |  | 
+| Data Science V              |  L3 typically < 8 years    |  Proficient or Authority  "Business Alignment" and "Communication"  | 25% authority                   | High end to end impact; | 
+| Principal Data Scientist    |  L4 not experience related | Proficient or Authority all DS specific                             | 50% Authority                   | Strong self awareness, Strong on general areas such as business acumen | 
           
 
                                                                                                                                                                                                      
 | Title/Job                             |  Industry Comparison       | Key Competencies                                                                                | Other Competencies              |     Notes  |
 | ------------------------------------- |:-------------------------- |:-----------------------------------------------------------------------------------------------:| -------------------------------:| ----------:|
-| Machine Learning Engineer III         |  L2 typically 2-4 years    | Proficient: "Machine Learning Analysis"  and "Tech Design, Implementation and Code Ownership"   |  50% emerging, 50% proficient   |  Comparable to SWDev III |
-| Machine Learning Engineer IV          |  L3 typically 5+  years    | Proficient: "Error, Causality, Inference" and "System Design"                                   | 75% proficient; some authority  |  | 
-| Machine Learning Engineer V           |  L3 typically < 8 years    |  Proficient or Authority "Communication" and "Technical Change"                                 | 90% proficient; some authority  | High end to end impact software and data systems;   | 
-| Principal Machine Learning Engineer   |  L4 not experience related | All DS specific                                                                                 | 50% Proficient; 50% Authority   | Strong self awareness, Strong on general areas such as business acumen | 
+| Machine Learning Engineer III         |  L2 typically 2-4 years    | Proficient: "Machine Learning Analysis"  and "Tech Design, Implementation and Code Ownership"   | 50% emerging, 50% proficient    |  Comparable to SWDev III |
+| Machine Learning Engineer IV          |  L3 typically 5+  years    | Proficient: "Error, Causality, Inference" and "System Design"                                   | 75% proficient                  |  | 
+| Machine Learning Engineer V           |  L3 typically < 8 years    |  Proficient or Authority "Communication" and "Technical Change"                                 | 25% authority                   | High end to end impact software and data systems;   | 
+| Principal Machine Learning Engineer   |  L4 not experience related | All DS specific                                                                                 | 50% Authority                   | Strong self awareness, Strong on general areas such as business acumen | 
                                        

--- a/competencies/roles/DeveloperLevelMapping.md
+++ b/competencies/roles/DeveloperLevelMapping.md
@@ -7,7 +7,7 @@ The three categories of competencies can be used to map to typical job titles sp
 | SW Dev I (junior)         |                                                              |                                |  New Grad, or first one or two years |
 | SW Dev II                 |                                                              |  75% emerging, 25% proficient  | Integrated into the software practice at Properly |
 | SW Dev III (intermediate) | Proficient: "Tech Design, Implementation and Code Ownership" | 50% emerging, 50% proficient   | Strong in knowledge and execution |
-| SW Dev IV (senior I)      | Proficient: "System Design"                                  | 50% proficient; some authority | May be expert or generalist  |
-| SW Dev V (senior II)      | Proficient: "Communication"                                  | 75% proficient; some authority | Expanded impact across teams / org |
-| Principal SW Dev          | Proficient: "Technical Change"                               | 50% Proficient; 50% Authority  | Strong self awareness, Strong on general areas such as business acumen |
+| SW Dev IV (senior I)      | Proficient: "System Design"                                  | 75%  proficient                | May be expert or generalist  |
+| SW Dev V (senior II)      | Proficient: "Communication"                                  | 25% authority                  | Expanded impact across teams / org |
+| Principal SW Dev          | Proficient: "Technical Change"                               | 50% Authority                  | Strong self awareness, Strong on general areas such as business acumen |
 | Distinguished             | Authority: "Technical Change"                                |                                | Broad authority or extreme depth in a technical branch |

--- a/competencies/roles/DeveloperLevelMapping.md
+++ b/competencies/roles/DeveloperLevelMapping.md
@@ -7,7 +7,7 @@ The three categories of competencies can be used to map to typical job titles sp
 | SW Dev I (junior)         |                                                              |                                |  New Grad, or first one or two years |
 | SW Dev II                 |                                                              |  75% emerging, 25% proficient  | Integrated into the software practice at Properly |
 | SW Dev III (intermediate) | Proficient: "Tech Design, Implementation and Code Ownership" | 50% emerging, 50% proficient   | Strong in knowledge and execution |
-| SW Dev IV (senior I)      | Proficient: "System Design"                                  | 75%  proficient                | May be expert or generalist  |
+| SW Dev IV (senior I)      | Proficient: "System Design"                                  | 75% proficient or greater      | May be expert or generalist  |
 | SW Dev V (senior II)      | Proficient: "Communication"                                  | 25% authority                  | Expanded impact across teams / org |
 | Principal SW Dev          | Proficient: "Technical Change"                               | 50% Authority                  | Strong self awareness, Strong on general areas such as business acumen |
 | Distinguished             | Authority: "Technical Change"                                |                                | Broad authority or extreme depth in a technical branch |


### PR DESCRIPTION
This is an update to recent changes that split the senior level roles. 

By previously focusing on having some competencies that were authority at dev 4 and  then expanding proficiencies at level 5 the level 4 roles became "not a real role that people would typically experience".

Reordering this to focus on proficiency growth first before going to more expertise (authority) makes the separation more natural and reflects a typical progression.  

Also effectively increases expectations for both 4 and 5. 