### PR TITLE
Remove industry comparison and distinguished level

### DIFF
--- a/competencies/roles/DataScienceLevelMapping.md
+++ b/competencies/roles/DataScienceLevelMapping.md
@@ -11,7 +11,6 @@ a role family called Machine Learning Engineer
 | Data Science III            |  Proficient: "Machine Learning Analysis"                             | 50% emerging, 50% proficient    |   |
 | Data Science IV             |  Proficient: "Error, Causality, Inference"                           | 75% proficient or greater       |  | 
 | Data Science V              |  Proficient or Authority  "Business Alignment" and "Communication"  | 25% authority                   | High end to end impact; | 
-| Principal Data Scientist    |  Proficient or Authority all DS specific                             | 50% Authority                   | Strong self awareness, Strong on general areas such as business acumen | 
           
 
                                                                                                                                                                                                      
@@ -20,5 +19,3 @@ a role family called Machine Learning Engineer
 | Machine Learning Engineer III         |  Proficient: "Machine Learning Analysis"  and "Tech Design, Implementation and Code Ownership"   | 50% emerging, 50% proficient    |  Comparable to SWDev III |
 | Machine Learning Engineer IV          |  Proficient: "Error, Causality, Inference" and "System Design"                                   | 75% proficient or greater       |  | 
 | Machine Learning Engineer V           |  Proficient or Authority "Communication" and "Technical Change"                                 | 25% authority                   | High end to end impact software and data systems;   | 
-| Principal Machine Learning Engineer   |  All DS specific                                                                                 | 50% Authority                   | Strong self awareness, Strong on general areas such as business acumen | 
-                                       

--- a/competencies/roles/DataScienceLevelMapping.md
+++ b/competencies/roles/DataScienceLevelMapping.md
@@ -5,20 +5,20 @@ This framework also uses the [Developer](./Developer.md)  competencies of
 a role family called Machine Learning Engineer
 
 
-| Title/Job                   |  Industry Comparison       | Key Competenies                                                     | Other Competencies              |     Notes  |
-| --------------------------- |:-------------------------- |:-------------------------------------------------------------------:| -------------------------------:| ----------:|
-| Data Science II             |  L1 typically 1-2 years    |                                                                     | 75% emerging, 25% proficient    | typically first one or two years |
-| Data Science III            |  L2 typically 2-4 years    | Proficient: "Machine Learning Analysis"                             | 50% emerging, 50% proficient    |   |
-| Data Science IV             |  L3 typically 5+  years    | Proficient: "Error, Causality, Inference"                           | 75% proficient or greater       |  | 
-| Data Science V              |  L3 typically < 8 years    |  Proficient or Authority  "Business Alignment" and "Communication"  | 25% authority                   | High end to end impact; | 
-| Principal Data Scientist    |  L4 not experience related | Proficient or Authority all DS specific                             | 50% Authority                   | Strong self awareness, Strong on general areas such as business acumen | 
+| Title/Job                   |  Key Competencies                                                     | Other Competencies              |     Notes  |
+| --------------------------- |:-------------------------------------------------------------------:| -------------------------------:| ----------:|
+| Data Science II             |  | 75% emerging, 25% proficient    | typically first one or two years |
+| Data Science III            |  Proficient: "Machine Learning Analysis"                             | 50% emerging, 50% proficient    |   |
+| Data Science IV             |  Proficient: "Error, Causality, Inference"                           | 75% proficient or greater       |  | 
+| Data Science V              |  Proficient or Authority  "Business Alignment" and "Communication"  | 25% authority                   | High end to end impact; | 
+| Principal Data Scientist    |  Proficient or Authority all DS specific                             | 50% Authority                   | Strong self awareness, Strong on general areas such as business acumen | 
           
 
                                                                                                                                                                                                      
-| Title/Job                             |  Industry Comparison       | Key Competencies                                                                                | Other Competencies              |     Notes  |
-| ------------------------------------- |:-------------------------- |:-----------------------------------------------------------------------------------------------:| -------------------------------:| ----------:|
-| Machine Learning Engineer III         |  L2 typically 2-4 years    | Proficient: "Machine Learning Analysis"  and "Tech Design, Implementation and Code Ownership"   | 50% emerging, 50% proficient    |  Comparable to SWDev III |
-| Machine Learning Engineer IV          |  L3 typically 5+  years    | Proficient: "Error, Causality, Inference" and "System Design"                                   | 75% proficient or greater       |  | 
-| Machine Learning Engineer V           |  L3 typically < 8 years    |  Proficient or Authority "Communication" and "Technical Change"                                 | 25% authority                   | High end to end impact software and data systems;   | 
-| Principal Machine Learning Engineer   |  L4 not experience related | All DS specific                                                                                 | 50% Authority                   | Strong self awareness, Strong on general areas such as business acumen | 
+| Title/Job                             |  Key Competencies                                                                                | Other Competencies              |     Notes  |
+| ------------------------------------- |:-----------------------------------------------------------------------------------------------:| -------------------------------:| ----------:|
+| Machine Learning Engineer III         |  Proficient: "Machine Learning Analysis"  and "Tech Design, Implementation and Code Ownership"   | 50% emerging, 50% proficient    |  Comparable to SWDev III |
+| Machine Learning Engineer IV          |  Proficient: "Error, Causality, Inference" and "System Design"                                   | 75% proficient or greater       |  | 
+| Machine Learning Engineer V           |  Proficient or Authority "Communication" and "Technical Change"                                 | 25% authority                   | High end to end impact software and data systems;   | 
+| Principal Machine Learning Engineer   |  All DS specific                                                                                 | 50% Authority                   | Strong self awareness, Strong on general areas such as business acumen | 
                                        

--- a/competencies/roles/DeveloperLevelMapping.md
+++ b/competencies/roles/DeveloperLevelMapping.md
@@ -10,4 +10,3 @@ The three categories of competencies can be used to map to typical job titles sp
 | SW Dev IV (senior I)      | Proficient: "System Design"                                  | 75% proficient or greater      | May be expert or generalist  |
 | SW Dev V (senior II)      | Proficient: "Communication"                                  | 25% authority                  | Expanded impact across teams / org |
 | Principal SW Dev          | Proficient: "Technical Change"                               | 50% Authority                  | Strong self awareness, Strong on general areas such as business acumen |
-| Distinguished             | Authority: "Technical Change"                                |                                | Broad authority or extreme depth in a technical branch |

--- a/competencies/roles/TechLeaderLevelMapping.md
+++ b/competencies/roles/TechLeaderLevelMapping.md
@@ -1,7 +1,7 @@
                                                                                                                                                                                                 
-| Title/Job                             |  Industry Comparison                          | Key Competencies                                                                                | Other Competencies              |     Notes  |
-| ------------------------------------- |:--------------------------------------- |:-----------------------------------------------------------------------------------------------:| -------------------------------:| ----------:|
-| Team Lead                             |  L3 first non-IC role (IC in L1, L2)    | Proficient: "Releasing Value"  and "Communication"                                              | 50%  proficient or above prof   |  Lateral to SWDev IV |
-| Eng Manager                           |  L4 Earlier                             | Proficient: "Developing Team" and "Facilitation"                                                | 75% proficient; some authority  |  | 
-| Senior Eng Manager / Head of          |  L4 Later                               | Prefer Authority "Communication" and "Tech Strategy, Alignment, Directional Leadership"         | 50% proficient; 50% authority   |  | 
+| Title/Job                             |  Key Competencies                                                                                | Other Competencies              |     Notes  |
+| ------------------------------------- |:-----------------------------------------------------------------------------------------------:| -------------------------------:| ----------:|
+| Team Lead                             |  Proficient: "Releasing Value"  and "Communication"                                              | 50%  proficient or above prof   |  Lateral to SWDev IV |
+| Eng Manager                           |  Proficient: "Developing Team" and "Facilitation"                                                | 75% proficient; some authority  |  | 
+| Senior Eng Manager / Head of          |  Prefer Authority "Communication" and "Tech Strategy, Alignment, Directional Leadership"         | 50% proficient; 50% authority   |  | 
                                                                   


### PR DESCRIPTION
- Removed distinguished developer level per discussion (needing a better measurement for the role)
- Removed industry comparison as "years of experience" does not seem to be a good indicator for our roles
- Removed principal data scientist and principal ML engineer roles (vaguely defined)

Principal and distinguished roles to be added back when we have a better idea of what skills should be demonstrated